### PR TITLE
Modify Range and Merge queries to track backend team OKRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a tool that continuously queries Parca instances for their data.
 
 It is based on the Parca gRPC APIs defined on https://buf.build/parca-dev/parca and uses the generated connect-go code via `go.buf.build/bufbuild/connect-go/parca-dev/parca`.
 
-### Installation 
+### Installation
 
 ```
 go install github.com/parca-dev/parca-load@latest
@@ -23,16 +23,16 @@ It runs a goroutine per API type.
 It starts a `Labels` goroutine that starts querying all labels on a Parca instance and then writes these into a shared map.
 The map is then read by the `Values` goroutine that selects a random label and queries all values for it.
 
-This process it repeated every 5 seconds.
+This process it repeated every 5 seconds (configurable).
 The entries of the shared map eventually expire to not query too old data.
 
-Similarly, it starts querying `ProfileTypes` every 10 seconds to know what profile types are available.
+Similarly, it starts querying `ProfileTypes` every 10 seconds (configurable) to know what profile types are available.
 The result is written to a shared map.
-Every 15 seconds there are `QueryRange` requests (querying up to 15min of data) for a random profile type.
+Every 15 seconds (configurable) there are `QueryRange` requests (querying 15min and 7 day ranges) for all series.
 
 Once the profile series are discovered above there are `Query` requests querying single profiles every 10 seconds.
 For these queries it picks a random timestamp of the available time range and queries a random report type (flame graph, top table, pprof download).
 
-Every 15 seconds there are `Query` requests that actually request merged profiles for either 15min, 5min or 1min, if enough data is available for each in a series.
+Every 15 seconds (configurable) there are `Query` requests that actually request merged profiles for either 15min, or 7 days, if enough data is available for each in a series.
 
 Metrics are collected and available on http://localhost:7171/metrics


### PR DESCRIPTION
This commit modifies both the Range and Merge queries to do 15m and 7 day queries (even though 15 min range is not tracked). This commit also changes merge queries to run against a profile type instead of a specific series (which is a more usual query to run).

Additionally a couple of cleanups were done:
- Removing executeLoop label to avoid goto statements.
- Logging was added/enhanced.

cc @brancz 