### PR TITLE
Allow querying arbitrary time ranges

### DIFF
--- a/querier.go
+++ b/querier.go
@@ -326,11 +326,6 @@ func (q *Querier) queryMerge(ctx context.Context) {
 
 	profileType := q.profileTypes[q.rng.Intn(len(q.profileTypes))]
 	for _, tr := range q.queryTimeRanges {
-		if tr > 24*time.Hour {
-			// TODO(asubiotto): This currently OOMs frostdb. Gradually remove
-			// this skip.
-			continue
-		}
 		rangeEnd := time.Now()
 		rangeStart := rangeEnd.Add(-1 * tr)
 


### PR DESCRIPTION
Given parca-load now has configurable time ranges we shouldn't limit the time ranges in the code anymore. Instead, configure the preferred time ranges via flags.
